### PR TITLE
Update rfc9193.cddl

### DIFF
--- a/cddl/rfc9193.cddl
+++ b/cddl/rfc9193.cddl
@@ -5,7 +5,7 @@ Content-Type   = Media-Type-Name *( *SP ";" *SP parameter )
 parameter      = token "=" ( token / quoted-string )
 
 token          = 1*tchar
-tchar          = "!" / "#" / "$" / "%" / "&" / "\'" / "*"
+tchar          = "!" / "#" / "$" / "%" / "&" / %x27 / "*"
                / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
                / DIGIT / ALPHA
 quoted-string  = %x22 *( qdtext / quoted-pair ) %x22


### PR DESCRIPTION
changed tchar use of escaped character to use hex value %x27