### PR TITLE
Fixed orphaned cmw.cddl file

### DIFF
--- a/cddl/cmw-start.cddl
+++ b/cddl/cmw-start.cddl
@@ -1,6 +1,1 @@
 start = cmw
-
-cmw = json-CMW / cbor-CMW
-
-json-CMW = json-record / json-collection
-cbor-CMW = cbor-record / cbor-collection / cbor-tag

--- a/cddl/cmw.cddl
+++ b/cddl/cmw.cddl
@@ -1,1 +1,4 @@
-cmw = cmw-array / cmw-cbor-tag<bytes> .feature "cbor"
+cmw = json-CMW / cbor-CMW
+
+json-CMW = json-record / json-collection
+cbor-CMW = cbor-record / cbor-collection / cbor-tag

--- a/cddl/frags.mk
+++ b/cddl/frags.mk
@@ -1,4 +1,5 @@
 CMW_FRAGS := cmw-start.cddl
+CMW_FRAGS += cmw.cddl
 CMW_FRAGS += cmw-record.cddl
 CMW_FRAGS += cmw-cbor-tag.cddl
 CMW_FRAGS += cmw-collection.cddl


### PR DESCRIPTION
Moved contents of cmw-start.cddl to cmw.cddl except for the single line `start = cmw` and updated frags.mk to include cmw.cddl

This PR fixes issue #72