### PR TITLE
Remove text in IANA considerations for JWT

### DIFF
--- a/draft-ietf-rats-msg-wrap.md
+++ b/draft-ietf-rats-msg-wrap.md
@@ -594,7 +594,6 @@ IANA is requested to add a new `cmw` claim to the "JSON Web Token Claims" sub-re
 
 * Claim Name: cmw
 * Claim Description: A RATS Conceptual Message Wrapper
-* Claim Value Type(s): JSON Object or JSON Array
 * Change Controller: IETF
 * Specification Document(s): {{type-n-val}} of {{&SELF}}
 


### PR DESCRIPTION
JWT registry doesn't have "Claim Value Type(s)" field.