### PR TITLE
what to check when assigning new CoAP C-Fs based on `application/cmw`

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -16,9 +16,11 @@ jobs:
   build:
     name: "Archive Issues and Pull Requests"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Note: No caching for this build!
 
@@ -37,6 +39,6 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Save Archive"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: archive.json

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     name: "Update Editor's Copy"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: "Checkout"
       uses: actions/checkout@v4
@@ -51,7 +53,7 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Archive Built Drafts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: |
           draft-*.html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "draft-*"
+  workflow_dispatch:
+    inputs:
+      email:
+        description: "Submitter email"
+        default: ""
+        type: string
 
 jobs:
   build:
@@ -11,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # See https://github.com/actions/checkout/issues/290
     - name: "Get Tag Annotations"
@@ -22,7 +28,7 @@ jobs:
       run: date -u "+date=%FT%T" >>"$GITHUB_OUTPUT"
 
     - name: "Caching"
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           .refcache
@@ -42,8 +48,10 @@ jobs:
       uses: martinthomson/i-d-template@v1
       with:
         make: upload
+      env:
+        UPLOAD_EMAIL: ${{ inputs.email }}
 
     - name: "Archive Submitted Drafts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: "versioned/draft-*-[0-9][0-9].*"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: "Update Generated Files"
       uses: martinthomson/i-d-template@v1

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@
 *~
 .tags
 /*-[0-9][0-9].xml
+/.*.mk
 /.gems/
 /.refcache
-/.targets.mk
 /.venv/
 /.vscode/
 /lib
@@ -17,7 +17,7 @@
 /versioned/
 Gemfile.lock
 archive.json
-draft-ftbs-rats-msg-wrap.xml
+draft-ietf-rats-msg-wrap.xml
 package-lock.json
 report.xml
 !requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,14 @@ include $(LIBDIR)/main.mk
 $(LIBDIR)/main.mk:
 ifneq (,$(shell grep "path *= *$(LIBDIR)" .gitmodules 2>/dev/null))
 	git submodule sync
-	git submodule update $(CLONE_ARGS) --init
+	git submodule update --init
 else
-	git clone -q --depth 10 $(CLONE_ARGS) \
-	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
+ifneq (,$(wildcard $(ID_TEMPLATE_HOME)))
+	ln -s "$(ID_TEMPLATE_HOME)" $(LIBDIR)
+else
+	git clone -q --depth 10 -b main \
+	    https://github.com/martinthomson/i-d-template $(LIBDIR)
+endif
 endif
 
 include cddl/frags.mk

--- a/draft-ietf-rats-msg-wrap.md
+++ b/draft-ietf-rats-msg-wrap.md
@@ -203,7 +203,7 @@ Each contains two or three members:
 `type`:
 : Either a text string representing a Content-Type (e.g., an EAT media type
 {{-rats-eat-mt}}) or an unsigned integer corresponding to a CoAP Content-Format
-number ({{Section 12.3 of -coap}}).
+ID ({{Section 12.3 of -coap}}).
 The latter MUST NOT be used in the JSON serialization.
 
 `value`:
@@ -491,7 +491,7 @@ with the following wire representation:
 Note that a Media-Type-Name can also be used with the CBOR record form,
 for example if it is known that the receiver cannot handle CoAP
 Content-Formats, or (unlike the case in point) if a CoAP Content-Format
-number has not been registrered.
+ID has not been registrered.
 
 ~~~ cbor-diag
 {::include cddl/cmw-example-2.diag}
@@ -946,9 +946,9 @@ Author/Change controller:
 Provisional registration:
 : no
 
-## CoAP Content Formats
+## CoAP Content-Formats
 
-IANA is requested to register the following Content-Format numbers in the "CoAP Content-Formats" registry, within the "Constrained RESTful Environments (CoRE) Parameters" registry group {{!IANA.core-parameters}}:
+IANA is requested to register the following Content-Format IDs in the "CoAP Content-Formats" registry, within the "Constrained RESTful Environments (CoRE) Parameters" registry group {{!IANA.core-parameters}}:
 
 | Content-Type | Content Coding | ID | Reference |
 | application/cmw+cbor | - | TBD1 | {{type-n-val}}, {{cbor-tag}} and {{cmw-coll}} of {{&SELF}} |
@@ -958,6 +958,15 @@ IANA is requested to register the following Content-Format numbers in the "CoAP 
 {: align="left" title="New CoAP Content Formats"}
 
 If possible, TBD1 and TBD2 should be assigned in the 256..9999 range.
+
+### Registering new CoAP Content-Formats for Parameterized CMW Media Types
+
+New CoAP Content-Formats can be created based on parameterized instances of the `application/cmw+json` and `application/cmw+cbor` media types.
+
+When assigning a new CoAP Content-Format ID for a CMW media type that utilizes the `cmwc_t` parameter, the registrar must check (directly or through the Designated Expert) that:
+
+* The corresponding CMW type is a collection ({{cmw-coll}}), and
+* The `cmwc_t` value is either a (non-relative) OID or an absolute URI.
 
 ## New SMI Numbers Registrations
 

--- a/draft-ietf-rats-msg-wrap.md
+++ b/draft-ietf-rats-msg-wrap.md
@@ -961,7 +961,7 @@ If possible, TBD1 and TBD2 should be assigned in the 256..9999 range.
 
 ### Registering new CoAP Content-Formats for Parameterized CMW Media Types
 
-New CoAP Content-Formats can be created based on parameterized instances of the `application/cmw+json` and `application/cmw+cbor` media types.
+New CoAP Content-Formats can be created based on parameterized instances of the `application/cmw+json`, `application/cmw+cbor`, `application/cmw+cose` and `application/cmw+jws` media types.
 
 When assigning a new CoAP Content-Format ID for a CMW media type that utilizes the `cmwc_t` parameter, the registrar must check (directly or through the Designated Expert) that:
 


### PR DESCRIPTION
Response attempt at @cabo's question: _"How do application/cmw+cbor with cmwc_t parameters get Content format numbers?"_
