### PR TITLE
s/"CMW CBOR Tag"/"CMW Tagged Item"/ to avoid ambiguity

### DIFF
--- a/cddl/cmw-cbor-tag.cddl
+++ b/cddl/cmw-cbor-tag.cddl
@@ -1,3 +1,3 @@
-cbor-tagged-cbor<tn, fmt> = #6.<tn>(bytes .cbor fmt)
+cbor-tagged-item-cbor<tn, fmt> = #6.<tn>(bytes .cbor fmt)
 
-cbor-tagged-data<tn> = #6.<tn>(bytes)
+cbor-tagged-item-data<tn> = #6.<tn>(bytes)

--- a/cddl/cmw-example-tag-1668576819-def.cddl
+++ b/cddl/cmw-example-tag-1668576819-def.cddl
@@ -1,4 +1,4 @@
-$cbor-tag /= cbor-tagged-cbor<1668576819, my-evidence>
+$cbor-tagged-item /= cbor-tagged-item-cbor<1668576819, my-evidence>
 
 my-evidence = {
   &(eat_nonce: 10) => bstr .size (8..64)

--- a/cddl/cmw-example-tag-1668576935-def.cddl
+++ b/cddl/cmw-example-tag-1668576935-def.cddl
@@ -1,1 +1,1 @@
-$cbor-tag /= cbor-tagged-data<1668576935>
+$cbor-tagged-item /= cbor-tagged-item-data<1668576935>

--- a/cddl/cmw-start.cddl
+++ b/cddl/cmw-start.cddl
@@ -3,4 +3,4 @@ start = cmw
 cmw = json-cmw / cbor-cmw
 
 json-cmw = json-record / json-collection
-cbor-cmw = cbor-record / cbor-collection / $cbor-tag
+cbor-cmw = cbor-record / cbor-collection / $cbor-tagged-item

--- a/draft-ietf-rats-msg-wrap.md
+++ b/draft-ietf-rats-msg-wrap.md
@@ -232,26 +232,26 @@ both Reference Values and Endorsements within the same `application/signed-corim
 shared by different conceptual messages.
 Future specifications may add new values to the `ind` field; see {{iana-ind-ext}}.
 
-## CMW CBOR Tags {#cbor-tag}
+## CMW Tagged Items {#cbor-tag}
 
-CMW of type CBOR Tag derive their tag numbers from a corresponding CoAP Content-Format ID using the `TN()` transform defined in {{Appendix B of RFC9277}}.
+CMW Tagged Items are CBOR Tags that derive their tag numbers from a corresponding CoAP Content-Format ID using the `TN()` transform defined in {{Appendix B of RFC9277}}.
 Such CBOR tag numbers are in range \[1668546817, 1668612095\].
 
 The RATS conceptual message is first serialized according to the Content-Format ID and then encoded as a CBOR byte string, to which the TN-derived tag number is prepended.
 
-The CMW CBOR Tag is defined in {{fig-cddl-cbor-tag}} using two different macros.
+The CMW Tagged Item is defined in {{fig-cddl-cbor-tag}} using two different macros.
 One for CBOR-encoded types, the other for all other types.
 Both macros take the CBOR tag number `tn` as a parameter.
-The `cbor-tagged-cbor` macro takes the CDDL definition of the associated conceptual message `fmt` as a second parameter.
+The `cbor-tagged-item-cbor` macro takes the CDDL definition of the associated conceptual message `fmt` as a second parameter.
 
 ~~~ cddl
 {::include cddl/cmw-cbor-tag.cddl}
 ~~~
 {: #fig-cddl-cbor-tag artwork-align="left"
-   title="CDDL definition of the CBOR Tag format macros"}
+   title="CDDL definition of the CMW Tagged Item macros"}
 
-To add a new CMW, the `$cbor-tag` type socket is extended with a new instance of the CMW CBOR Tag macro.
-For example, to associate conceptual messages of type `my-evidence` with CBOR Tag `1668576819`, one would extend `$cbor-tag` as follows:
+To add a new CMW, the `$cbor-tagged-item` type socket is extended with a new instance of the applicable CMW Tagged Item macro.
+For example, to associate conceptual messages of type `my-evidence` with CBOR Tag `1668576819`, one would extend `$cbor-tagged-item` as follows:
 
 ~~~ cddl
 {::include cddl/cmw-example-tag-1668576819-def.cddl}
@@ -499,7 +499,7 @@ ID has not been registrered.
 {::include cddl/cmw-example-2.diag}
 ~~~
 
-## CBOR Tag {#ex-ct}
+## CMW Tagged Item {#ex-ct}
 
 ~~~ cbor-diag
 {::include cddl/cmw-example-tag-1.diag}


### PR DESCRIPTION
Fix #148

This PR supersedes #172 using the name suggested by Laurence.