### PR TITLE
add appraisal policy to the CM types

### DIFF
--- a/cddl/cm-type.cddl
+++ b/cddl/cm-type.cddl
@@ -3,4 +3,5 @@ cm-type = &(
   endorsements: 1
   evidence: 2
   attestation-results: 3
+  appraisal-policy: 4
 )

--- a/draft-ietf-rats-msg-wrap.md
+++ b/draft-ietf-rats-msg-wrap.md
@@ -793,7 +793,7 @@ The initial registrations for the registry are detailed in {{tab-ind-regs}}.
 | 0 | Reference Values | {{cm-type}} of {{&SELF}} |
 | 1 | Endorsements | {{cm-type}} of {{&SELF}} |
 | 2 | Evidence | {{cm-type}} of {{&SELF}} |
-| 3 | Attestation of Results | {{cm-type}} of {{&SELF}} |
+| 3 | Attestation Results | {{cm-type}} of {{&SELF}} |
 | 4 | Appraisal Policy | {{cm-type}} of {{&SELF}} |
 | 5-31 | Unassigned | |
 {: #tab-ind-regs title="CMW Indicators Registry Initial Contents"}

--- a/draft-ietf-rats-msg-wrap.md
+++ b/draft-ietf-rats-msg-wrap.md
@@ -1111,6 +1111,7 @@ Michael B. Jones,
 Mike Ounsworth,
 Mohit Sethi,
 Russ Housley,
+Steven Bellock,
 Tom Jones,
 and
 Usama Sardar

--- a/draft-ietf-rats-msg-wrap.md
+++ b/draft-ietf-rats-msg-wrap.md
@@ -251,7 +251,8 @@ As such, it indicates which bits are allowed to be set in the `ind` byte string.
 {: #fig-cddl-cm-type artwork-align="left"
    title="CDDL definition of the CM Type"}
 
-The `cm-type` currently has four allowed values: Reference Values, Endorsements, Evidence and Attestation Results, as defined in {{Section 8 of -rats-arch}}.
+The `cm-type` currently has five allowed values: Reference Values, Endorsements, Evidence, Attestation Results, and Appraisal Policy, as defined in {{Section 8 of -rats-arch}}.
+Note that that an Appraisal Policy may refer to the appraisal of Evidence or Attestation Results, depending on whether the consumer of the conceptual message is a Verifier or a Relying Party.
 
 Future specifications that extend the RATS Conceptual Messages set can add new values to the `cm-type` using the process defined in {{iana-ind-ext}}.
 
@@ -789,11 +790,12 @@ The initial registrations for the registry are detailed in {{tab-ind-regs}}.
 
 | Indicator value | Conceptual Message name | Reference |
 |-----------------|-------------------------|-----------|
-| 0 | Reference Values | {{&SELF}} |
-| 1 | Endorsements | {{&SELF}} |
-| 2 | Evidence | {{&SELF}} |
-| 3 | Attestation Results | {{&SELF}} |
-| 4-31 | Unassigned | {{&SELF}} |
+| 0 | Reference Values | {{cm-type}} of {{&SELF}} |
+| 1 | Endorsements | {{cm-type}} of {{&SELF}} |
+| 2 | Evidence | {{cm-type}} of {{&SELF}} |
+| 3 | Attestation of Results | {{cm-type}} of {{&SELF}} |
+| 4 | Appraisal Policy | {{cm-type}} of {{&SELF}} |
+| 5-31 | Unassigned | |
 {: #tab-ind-regs title="CMW Indicators Registry Initial Contents"}
 
 ### Provisional Registration

--- a/provisional/cmw-indicators-registry.md
+++ b/provisional/cmw-indicators-registry.md
@@ -16,4 +16,5 @@ For rationale about how to pick names and codepoints, see [Section 8.4 of draft-
 | 1 | Endorsements |
 | 2 | Evidence |
 | 3 | Attestation Results	|
-| 4-15 | Unassigned	|
+| 4 | Appraisal Policy |
+| 5-15 | Unassigned	|


### PR DESCRIPTION
While defining appraisal policies is beyond the scope of the current RATS charter, it makes sense to add a code point for the conceptual message.

Fix #229 